### PR TITLE
fix(tui): stabilize packaged server startup

### DIFF
--- a/apps/tui/package.json
+++ b/apps/tui/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "@opentui/core": "^0.1.90",
     "@opentui/react": "^0.1.90",
+    "node-pty": "^1.1.0",
     "react": "^19.0.0",
     "react-devtools-core": "^7.0.1",
     "web-tree-sitter": "0.25.10",

--- a/apps/tui/scripts/bundle-server-dist.mjs
+++ b/apps/tui/scripts/bundle-server-dist.mjs
@@ -10,10 +10,6 @@ const serverRoot = path.resolve(repoRoot, "apps/server");
 const serverDistSource = path.resolve(serverRoot, "dist");
 const serverDistTarget = path.resolve(tuiRoot, "dist/server");
 const serverClientSource = path.resolve(serverDistSource, "client");
-const nodePtySource = path.resolve(
-  repoRoot,
-  "node_modules/.bun/node-pty@1.1.0/node_modules/node-pty",
-);
 const nodePtyTarget = path.resolve(serverDistTarget, "node_modules/node-pty");
 const nodePtyRuntimeEntries = [
   "LICENSE",
@@ -23,6 +19,46 @@ const nodePtyRuntimeEntries = [
   "prebuilds",
   "typings",
 ];
+
+async function exists(targetPath) {
+  try {
+    await fs.access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveNodePtySource() {
+  const directCandidates = [
+    path.resolve(tuiRoot, "node_modules/node-pty"),
+    path.resolve(repoRoot, "node_modules/node-pty"),
+  ];
+
+  for (const candidate of directCandidates) {
+    if (await exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  const bunStoreDir = path.resolve(repoRoot, "node_modules/.bun");
+  const bunStoreEntries = await fs.readdir(bunStoreDir, { withFileTypes: true }).catch(() => []);
+
+  for (const entry of bunStoreEntries) {
+    if (!entry.isDirectory() || !entry.name.startsWith("node-pty@")) {
+      continue;
+    }
+
+    const candidate = path.resolve(bunStoreDir, entry.name, "node_modules/node-pty");
+    if (await exists(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Unable to locate node-pty runtime files under ${tuiRoot}/node_modules or ${bunStoreDir}.`,
+  );
+}
 
 function run(command, args, cwd) {
   return new Promise((resolve, reject) => {
@@ -65,7 +101,10 @@ await run(
   ],
   serverRoot,
 );
-await fs.cp(serverClientSource, path.resolve(serverDistTarget, "client"), { recursive: true });
+if (await exists(serverClientSource)) {
+  await fs.cp(serverClientSource, path.resolve(serverDistTarget, "client"), { recursive: true });
+}
+const nodePtySource = await resolveNodePtySource();
 await fs.mkdir(path.dirname(nodePtyTarget), { recursive: true });
 await fs.rm(nodePtyTarget, { recursive: true, force: true });
 await fs.mkdir(nodePtyTarget, { recursive: true });

--- a/apps/tui/src/serverSupervisor.test.ts
+++ b/apps/tui/src/serverSupervisor.test.ts
@@ -137,7 +137,7 @@ describe("startServerSupervisor", () => {
     expect(children[0]?.kill).toHaveBeenCalledWith("SIGTERM");
   });
 
-  it("uses node for packaged production server launches", async () => {
+  it("uses the current runtime for packaged production server launches", async () => {
     const spawnImpl = vi.fn(() => new FakeChildProcess() as unknown as ChildProcess);
 
     const server = await startServerSupervisor(
@@ -152,7 +152,7 @@ describe("startServerSupervisor", () => {
       },
     );
 
-    expect((spawnImpl as any).mock.calls[0][0]).toMatch(/(^|\/)node$/);
+    expect((spawnImpl as any).mock.calls[0][0]).toBe(process.execPath);
     expect((spawnImpl as any).mock.calls[0][1][0]).toContain("/apps/server/dist/index.mjs");
 
     server.stop();
@@ -174,7 +174,7 @@ describe("startServerSupervisor", () => {
       },
     );
 
-    expect((spawnImpl as any).mock.calls[0][0]).toMatch(/(^|\/)node$/);
+    expect((spawnImpl as any).mock.calls[0][0]).toBe(process.execPath);
     expect((spawnImpl as any).mock.calls[0][1][0]).toContain("/server/index.js");
 
     server.stop();

--- a/apps/tui/src/serverSupervisor.ts
+++ b/apps/tui/src/serverSupervisor.ts
@@ -75,7 +75,7 @@ function resolveBundledServerCommand(env: NodeJS.ProcessEnv): string {
   if (configured) {
     return configured;
   }
-  return process.versions.bun !== undefined ? "node" : process.execPath;
+  return process.execPath;
 }
 
 function readBooleanEnv(value: string | undefined): boolean | undefined {

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
       "dependencies": {
         "@opentui/core": "^0.1.90",
         "@opentui/react": "^0.1.90",
+        "node-pty": "^1.1.0",
         "react": "^19.0.0",
         "react-devtools-core": "^7.0.1",
         "web-tree-sitter": "0.25.10",


### PR DESCRIPTION
I had my clanker look into this problem and create a fix.

## Summary

Fix packaged TUI startup so the published runtime no longer exits before the server is ready.

## Changes

- launch the bundled server with the current runtime instead of forcing `node`
- add `node-pty` as a TUI runtime dependency
- harden the TUI packaging script to find `node-pty` reliably
- skip copying `apps/server/dist/client` when it does not exist so `build:tui` succeeds without a built web bundle
- update supervisor tests accordingly

## Verification

- `bun run build:tui`
- `bun fmt`
- `bun lint`
- `HOME=/tmp XDG_CONFIG_HOME=/tmp bun typecheck`
- `HOME=/tmp XDG_CONFIG_HOME=/tmp bun run --cwd apps/tui test src/serverSupervisor.test.ts`

## Repro

Published `bunx @maria_rcks/t1code` was failing with:

`Server exited before becoming ready (1)`