### PR TITLE
feat(tui): Add Terminal Theme Resolver

### DIFF
--- a/apps/tui/src/index.tsx
+++ b/apps/tui/src/index.tsx
@@ -4,8 +4,16 @@ import { createCliRenderer } from "@opentui/core";
 import { createTestRenderer } from "@opentui/core/testing";
 import { createRoot } from "@opentui/react";
 import React from "react";
+import { DEFAULT_APP_THEME } from "@t3tools/client-core";
 import { resolveTuiPaths } from "./config";
 import { readPrefs } from "./prefs";
+import {
+  normalizeRendererThemeMode,
+  resolveTerminalPalette,
+  shouldResolveTerminalPalette,
+  shouldTrackSystemThemeMode,
+} from "./rendererTheme";
+import { normalizeTuiThemeId, resolveTerminalThemeMode, resolveTuiTheme } from "./theme";
 import { App } from "./ui";
 
 function readBooleanEnv(value: string | undefined): boolean | undefined {
@@ -71,15 +79,31 @@ if (process.env.T1CODE_HEADLESS === "1") {
   let interruptRequestToken = 0;
   const paths = resolveTuiPaths();
   const prefs = await readPrefs(paths);
-  const rendererBackgroundColor = prefs.appSettings?.theme === "light" ? "#f5f5f5" : "#171717";
+  const appTheme = prefs.appSettings?.theme ?? DEFAULT_APP_THEME;
+  const tuiThemeId = normalizeTuiThemeId(prefs.tuiThemeId);
+  const tracksSystemThemeMode = shouldTrackSystemThemeMode(appTheme);
+  const usesTerminalPalette = shouldResolveTerminalPalette(tuiThemeId);
+  const shouldDeferInitialBackground = tracksSystemThemeMode || usesTerminalPalette;
+  const initialTheme = resolveTuiTheme(appTheme, tuiThemeId);
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
     useAlternateScreen: shouldUseAlternateScreen(),
     useMouse: shouldUseMouse(),
     enableMouseMovement: shouldEnableMouseMovement(),
     useKittyKeyboard: shouldUseKittyKeyboard() ? { events: true } : null,
-    backgroundColor: rendererBackgroundColor,
+    ...(!shouldDeferInitialBackground ? { backgroundColor: initialTheme.palette.canvas } : {}),
   });
+  const initialRendererThemeMode = normalizeRendererThemeMode(renderer.themeMode);
+  const detectedTerminalPalette = usesTerminalPalette
+    ? await resolveTerminalPalette(renderer, { clearCache: true })
+    : { colors: null, durationMs: 0 };
+  const initialSystemThemeMode =
+    resolveTerminalThemeMode(detectedTerminalPalette.colors) ?? initialRendererThemeMode;
+  const rendererTheme = resolveTuiTheme(appTheme, tuiThemeId, {
+    systemMode: initialSystemThemeMode,
+    terminalColors: detectedTerminalPalette.colors,
+  });
+  renderer.setBackgroundColor?.(rendererTheme.palette.canvas);
   const root = createRoot(renderer);
 
   const renderApp = () => {
@@ -88,6 +112,10 @@ if (process.env.T1CODE_HEADLESS === "1") {
         renderer={renderer}
         interruptRequestToken={interruptRequestToken}
         onRequestExit={() => shutdown(0)}
+        initialTuiThemeId={tuiThemeId}
+        initialSystemThemeMode={initialSystemThemeMode}
+        initialTerminalThemeColors={detectedTerminalPalette.colors}
+        {...(prefs.appSettings ? { initialAppSettings: prefs.appSettings } : {})}
       />,
     );
   };

--- a/apps/tui/src/prefs.test.ts
+++ b/apps/tui/src/prefs.test.ts
@@ -35,6 +35,7 @@ describe("prefs", () => {
     tempRoots.push(root);
 
     await writePrefs(paths, {
+      tuiThemeId: "terminal-match",
       selectedThreadId: "thread-1",
       locallyUnreadThreadIds: ["thread-2"],
       threadLastVisitedAtById: {
@@ -74,6 +75,7 @@ describe("prefs", () => {
     });
 
     await expect(readPrefs(paths)).resolves.toEqual({
+      tuiThemeId: "terminal-match",
       selectedThreadId: "thread-1",
       locallyUnreadThreadIds: ["thread-2"],
       threadLastVisitedAtById: {

--- a/apps/tui/src/prefs.ts
+++ b/apps/tui/src/prefs.ts
@@ -8,6 +8,7 @@ import {
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { TuiPaths } from "./config";
+import type { TuiThemeId } from "./theme";
 
 export interface PersistedComposerImageAttachment {
   readonly type: "image";
@@ -40,6 +41,7 @@ export interface PersistedDraftThreadState {
 }
 
 export interface TuiPrefs {
+  readonly tuiThemeId?: TuiThemeId;
   readonly selectedProjectId?: string;
   readonly selectedThreadId?: string;
   readonly expandedProjectIds?: readonly string[];

--- a/apps/tui/src/rendererTheme.ts
+++ b/apps/tui/src/rendererTheme.ts
@@ -1,0 +1,63 @@
+import { performance } from "node:perf_hooks";
+import type { AppTheme } from "@t3tools/client-core";
+import {
+  TERMINAL_MATCH_THEME_ID,
+  hasUsableTerminalColors,
+  type TerminalColors,
+  type TuiThemeId,
+  type TuiThemeMode,
+} from "./theme";
+
+export interface ThemeAwareRenderer {
+  readonly themeMode?: unknown;
+  getPalette?: (options?: { size?: number; timeout?: number }) => Promise<TerminalColors>;
+  clearPaletteCache?: () => void;
+}
+
+export interface ResolvedTerminalPalette {
+  readonly colors: TerminalColors | null;
+  readonly durationMs: number;
+}
+
+export function shouldTrackSystemThemeMode(theme: AppTheme | undefined): boolean {
+  return theme === "system";
+}
+
+export function shouldResolveTerminalPalette(themeId: TuiThemeId): boolean {
+  return themeId === TERMINAL_MATCH_THEME_ID;
+}
+
+export function shouldListenForRendererThemeChanges(
+  theme: AppTheme | undefined,
+  themeId: TuiThemeId,
+): boolean {
+  return shouldTrackSystemThemeMode(theme) || shouldResolveTerminalPalette(themeId);
+}
+
+export function normalizeRendererThemeMode(value: unknown): TuiThemeMode | null {
+  return value === "light" || value === "dark" ? value : null;
+}
+
+export async function resolveTerminalPalette(
+  renderer: ThemeAwareRenderer,
+  options: { clearCache?: boolean } = {},
+): Promise<ResolvedTerminalPalette> {
+  if (!renderer.getPalette) {
+    return { colors: null, durationMs: 0 };
+  }
+
+  const startedAt = performance.now();
+  if (options.clearCache) {
+    renderer.clearPaletteCache?.();
+  }
+
+  try {
+    const colors = await renderer.getPalette({ size: 16 });
+    return {
+      colors: hasUsableTerminalColors(colors) ? colors : null,
+      durationMs: performance.now() - startedAt,
+    };
+  } catch {
+    return { colors: null, durationMs: performance.now() - startedAt };
+  }
+}

--- a/apps/tui/src/theme.test.ts
+++ b/apps/tui/src/theme.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TUI_THEME,
+  DEFAULT_TUI_THEME_ID,
+  type TerminalColors,
+  hasUsableTerminalColors,
+  normalizeTuiThemeId,
+  resolveTuiTheme,
+  resolveTuiThemeMode,
+} from "./theme";
+
+const SAMPLE_TERMINAL_COLORS: TerminalColors = {
+  palette: [
+    "#2e3440",
+    "#bf616a",
+    "#a3be8c",
+    "#ebcb8b",
+    "#81a1c1",
+    "#b48ead",
+    "#88c0d0",
+    "#e5e9f0",
+    "#4c566a",
+    "#d08770",
+    "#a3be8c",
+    "#ebcb8b",
+    "#81a1c1",
+    "#b48ead",
+    "#8fbcbb",
+    "#eceff4",
+  ],
+  defaultForeground: "#e5e9f0",
+  defaultBackground: "#2e3440",
+  cursorColor: null,
+  mouseForeground: null,
+  mouseBackground: null,
+  tekForeground: null,
+  tekBackground: null,
+  highlightBackground: null,
+  highlightForeground: null,
+};
+
+const EMPTY_TERMINAL_COLORS: TerminalColors = {
+  palette: Array.from({ length: 16 }, () => null),
+  defaultForeground: null,
+  defaultBackground: null,
+  cursorColor: null,
+  mouseForeground: null,
+  mouseBackground: null,
+  tekForeground: null,
+  tekBackground: null,
+  highlightBackground: null,
+  highlightForeground: null,
+};
+
+const PARTIAL_TERMINAL_COLORS: TerminalColors = {
+  palette: Array.from({ length: 16 }, () => null),
+  defaultForeground: null,
+  defaultBackground: "#2e3440",
+  cursorColor: null,
+  mouseForeground: null,
+  mouseBackground: null,
+  tekForeground: null,
+  tekBackground: null,
+  highlightBackground: null,
+  highlightForeground: null,
+};
+
+describe("resolveTuiThemeMode", () => {
+  it("falls back to dark and respects detected system mode when provided", () => {
+    expect(resolveTuiThemeMode("system")).toBe("dark");
+    expect(resolveTuiThemeMode("system", "light")).toBe("light");
+    for (const theme of ["dark", "light", undefined] as const) {
+      expect(resolveTuiThemeMode(theme)).toBe(theme ?? "dark");
+    }
+  });
+});
+
+describe("hasUsableTerminalColors", () => {
+  it("requires both a usable background and text color source", () => {
+    expect(hasUsableTerminalColors(EMPTY_TERMINAL_COLORS)).toBe(false);
+    expect(hasUsableTerminalColors(PARTIAL_TERMINAL_COLORS)).toBe(false);
+    expect(hasUsableTerminalColors(SAMPLE_TERMINAL_COLORS)).toBe(true);
+    expect(hasUsableTerminalColors(null)).toBe(false);
+  });
+});
+
+describe("normalizeTuiThemeId", () => {
+  it("accepts known ids and normalizes unknown values at the boundary", () => {
+    expect(normalizeTuiThemeId("default")).toBe("default");
+    expect(normalizeTuiThemeId("terminal-match")).toBe("terminal-match");
+    expect(normalizeTuiThemeId("not-a-theme")).toBe(DEFAULT_TUI_THEME_ID);
+    expect(normalizeTuiThemeId(null)).toBe(DEFAULT_TUI_THEME_ID);
+  });
+});
+
+describe("resolveTuiTheme", () => {
+  it.each([
+    {
+      input: "dark" as const,
+      expected: {
+        mode: "dark",
+        canvas: "#171717",
+        composerSend: "#2f438e",
+        codeBlockBackground: "#101010",
+        diffSign: "#4ade80",
+        buttonText: "#d1d5db",
+      },
+    },
+    {
+      input: "light" as const,
+      expected: {
+        mode: "light",
+        canvas: "#f5f5f5",
+        composerSend: "#60a5fa",
+        codeBlockBackground: "#101010",
+        diffSign: "#f87171",
+        buttonText: "#f5f5f5",
+      },
+    },
+  ])("preserves the existing $input theme values", ({ input, expected }) => {
+    const theme = resolveTuiTheme(input);
+
+    expect(theme.id).toBe("default");
+    expect(theme.mode).toBe(expected.mode);
+    expect(theme.palette.canvas).toBe(expected.canvas);
+    expect(theme.palette.composerSend).toBe(expected.composerSend);
+    expect(theme.codeBlock.background).toBe(expected.codeBlockBackground);
+    expect(
+      input === "dark" ? theme.diffViewer.addedSignColor : theme.diffViewer.removedSignColor,
+    ).toBe(expected.diffSign);
+    expect(input === "dark" ? theme.colors.sendDotActive : theme.colors.primaryButtonText).toBe(
+      expected.buttonText,
+    );
+  });
+
+  it("lets the default preset follow the detected system mode", () => {
+    const theme = resolveTuiTheme("system", DEFAULT_TUI_THEME_ID, { systemMode: "light" });
+
+    expect(theme.mode).toBe("light");
+    expect(theme.id).toBe("default");
+    expect(theme.palette.canvas).toBe("#f5f5f5");
+  });
+
+  it("builds the terminal-match preset from terminal colors", () => {
+    const theme = resolveTuiTheme("system", "terminal-match", {
+      systemMode: "dark",
+      terminalColors: SAMPLE_TERMINAL_COLORS,
+    });
+
+    expect(theme.mode).toBe("dark");
+    expect(theme.id).toBe("terminal-match");
+    expect(theme.palette.canvas).toBe("#2e344000");
+    expect(theme.palette.text).toBe("#e5e9f0");
+    expect(theme.palette.accent).toBe("#88c0d0");
+    expect(theme.palette.composerSend).toBe("#88c0d0");
+    expect(theme.colors.selectedText).toBe("#2e3440");
+    expect(theme.status.planReady).toBe("#b48ead");
+    expect(theme.diffViewer.addedSignColor).toBe("#a3be8c");
+  });
+
+  it("falls back to the default preset when terminal-match colors are unavailable", () => {
+    expect(resolveTuiTheme("dark", "terminal-match")).toBe(DEFAULT_TUI_THEME);
+    expect(
+      resolveTuiTheme("dark", "terminal-match", {
+        terminalColors: EMPTY_TERMINAL_COLORS,
+      }),
+    ).toBe(DEFAULT_TUI_THEME);
+  });
+
+  it("falls back to the default preset when terminal colors are incomplete", () => {
+    expect(
+      resolveTuiTheme("dark", "terminal-match", {
+        terminalColors: PARTIAL_TERMINAL_COLORS,
+      }),
+    ).toBe(DEFAULT_TUI_THEME);
+  });
+});

--- a/apps/tui/src/theme.ts
+++ b/apps/tui/src/theme.ts
@@ -1,0 +1,751 @@
+import type { AppTheme } from "@t3tools/client-core";
+
+export interface TerminalColors {
+  readonly palette: readonly (string | null)[];
+  readonly defaultForeground: string | null;
+  readonly defaultBackground: string | null;
+  readonly cursorColor: string | null;
+  readonly mouseForeground: string | null;
+  readonly mouseBackground: string | null;
+  readonly tekForeground: string | null;
+  readonly tekBackground: string | null;
+  readonly highlightBackground: string | null;
+  readonly highlightForeground: string | null;
+}
+
+export type TuiColor = string;
+
+export const TERMINAL_MATCH_THEME_ID = "terminal-match" as const;
+export const TUI_THEME_IDS = ["default", TERMINAL_MATCH_THEME_ID] as const;
+export type TuiThemeId = (typeof TUI_THEME_IDS)[number];
+export const DEFAULT_TUI_THEME_ID = "default" as const;
+export const TUI_THEME_LABELS: Record<TuiThemeId, string> = {
+  default: "Default",
+  [TERMINAL_MATCH_THEME_ID]: "Terminal Match",
+};
+
+export type TuiThemeMode = "light" | "dark";
+
+type TuiThemeDetails = {
+  attachmentPillTones: readonly { backgroundColor: TuiColor; textColor: TuiColor }[];
+  codeBlock: { background: TuiColor; language: TuiColor; copyIcon: TuiColor };
+  status: { awaitingInput: TuiColor; working: TuiColor; planReady: TuiColor; pulse: TuiColor };
+  diffViewer: {
+    addedBg: TuiColor;
+    removedBg: TuiColor;
+    addedContentBg: TuiColor;
+    removedContentBg: TuiColor;
+    addedSignColor: TuiColor;
+    removedSignColor: TuiColor;
+  };
+  colors: {
+    workEntryErrorAccent: TuiColor;
+    destructiveIcon: TuiColor;
+    controlKnob: TuiColor;
+    primaryButtonText: TuiColor;
+    sendDotIdle: TuiColor;
+    sendDotActive: TuiColor;
+    selectedText: TuiColor;
+  };
+};
+
+export interface ResolveTuiThemeOptions {
+  systemMode?: TuiThemeMode | null;
+  terminalColors?: TerminalColors | null;
+}
+
+const DEFAULT_DARK_PALETTE = {
+  canvas: "#171717",
+  sidebar: "#151515",
+  main: "#171717",
+  surface: "#1b1b1b",
+  surfaceAlt: "#1f1f1f",
+  input: "#111111",
+  surfaceUser: "#202020",
+  surfacePlan: "#1f221c",
+  surfaceWarn: "#262016",
+  surfaceInfo: "#1d2026",
+  footer: "#171717",
+  diff: "#1b1b1b",
+  popup: "#1c1c1c",
+  scrim: "#00000099",
+  border: "#252525",
+  divider: "#2d2d2d",
+  control: "transparent",
+  controlHover: "#202020",
+  controlActive: "#292929",
+  controlActiveStrong: "#1e1e1e",
+  controlInset: "#141414",
+  controlInsetHover: "#1a1a1a",
+  composerPanel: "#1a1a1a",
+  composerBorder: "#2a3f95",
+  composerBorderMuted: "#313131",
+  composerSend: "#2f438e",
+  composerSendHover: "#3c57ba",
+  composerStop: "#dc2626",
+  composerStopHover: "#ef4444",
+  accent: "#7c87ff",
+  cursor: "#d4d4d4",
+  selection: "#1f4f95",
+  selectionActive: "#2b61b0",
+  text: "#f5f5f5",
+  muted: "#a3a3a3",
+  subtle: "#737373",
+  success: "#10b981",
+  info: "#3b82f6",
+  warning: "#f59e0b",
+  claude: "#d97757",
+  macRed: "#ff5f57",
+  macYellow: "#febc2e",
+  macGreen: "#28c840",
+} satisfies Record<string, TuiColor>;
+
+type TuiPaletteShape = typeof DEFAULT_DARK_PALETTE;
+export type TuiPalette = { [Key in keyof TuiPaletteShape]: TuiColor };
+
+const DEFAULT_THEME_DETAILS = {
+  attachmentPillTones: [
+    { backgroundColor: "#1d2026", textColor: "#3b82f6" },
+    { backgroundColor: "#241b2f", textColor: "#a78bfa" },
+    { backgroundColor: "#2a2417", textColor: "#facc15" },
+    { backgroundColor: "#2a1b1b", textColor: "#f87171" },
+    { backgroundColor: "#1c2721", textColor: "#34d399" },
+    { backgroundColor: "#272019", textColor: "#fb923c" },
+  ],
+  codeBlock: {
+    background: "#101010",
+    language: "#8a8a8a",
+    copyIcon: "#9a9a9a",
+  },
+  status: {
+    awaitingInput: "#818cf8",
+    working: "#7dd3fc",
+    planReady: "#a78bfa",
+    pulse: "#3b82f6",
+  },
+  diffViewer: {
+    addedBg: "#173124",
+    removedBg: "#3a1f1f",
+    addedContentBg: "#1d3a2b",
+    removedContentBg: "#442525",
+    addedSignColor: "#4ade80",
+    removedSignColor: "#f87171",
+  },
+  colors: {
+    workEntryErrorAccent: "#fda4af",
+    destructiveIcon: "#fda4af",
+    controlKnob: "#f5f5f5",
+    primaryButtonText: "#f5f5f5",
+    sendDotIdle: "#6b7280",
+    sendDotActive: "#d1d5db",
+    selectedText: "#f5f5f5",
+  },
+} satisfies TuiThemeDetails;
+
+export type TuiTheme = {
+  id: TuiThemeId;
+  mode: TuiThemeMode;
+  palette: TuiPalette;
+} & TuiThemeDetails;
+
+const DEFAULT_DARK_THEME: TuiTheme = {
+  id: "default",
+  mode: "dark",
+  palette: DEFAULT_DARK_PALETTE,
+  ...DEFAULT_THEME_DETAILS,
+};
+
+const DEFAULT_LIGHT_PALETTE: TuiPalette = {
+  ...DEFAULT_DARK_PALETTE,
+  canvas: "#f5f5f5",
+  sidebar: "#eeeeee",
+  main: "#f7f7f7",
+  surface: "#ffffff",
+  surfaceAlt: "#f1f1f1",
+  input: "#ffffff",
+  surfaceUser: "#ececec",
+  surfacePlan: "#eef6ec",
+  surfaceWarn: "#fff5e6",
+  surfaceInfo: "#eef4ff",
+  footer: "#f7f7f7",
+  diff: "#fafafa",
+  popup: "#ffffff",
+  scrim: "#00000022",
+  border: "#dddddd",
+  divider: "#d8d8d8",
+  controlHover: "#ebebeb",
+  controlActive: "#e2e2e2",
+  controlActiveStrong: "#cdcdcd",
+  controlInset: "#e7e7e7",
+  controlInsetHover: "#dddddd",
+  composerPanel: "#ffffff",
+  composerBorder: "#0891b2",
+  composerBorderMuted: "#d0d0d0",
+  composerSend: "#60a5fa",
+  composerSendHover: "#3b82f6",
+  accent: "#0891b2",
+  cursor: "#a3a3a3",
+  selection: "#dbeafe",
+  selectionActive: "#bfdbfe",
+  text: "#171717",
+  muted: "#666666",
+  subtle: "#8a8a8a",
+  success: "#059669",
+  info: "#2563eb",
+  warning: "#d97706",
+  claude: "#c96d4d",
+};
+
+const DEFAULT_LIGHT_THEME: TuiTheme = {
+  ...DEFAULT_DARK_THEME,
+  id: "default",
+  mode: "light",
+  palette: DEFAULT_LIGHT_PALETTE,
+  colors: {
+    ...DEFAULT_DARK_THEME.colors,
+    selectedText: "#171717",
+  },
+};
+
+export const DEFAULT_TUI_THEME = DEFAULT_DARK_THEME;
+
+function defaultThemeForMode(mode: TuiThemeMode): TuiTheme {
+  return mode === "light" ? DEFAULT_LIGHT_THEME : DEFAULT_DARK_THEME;
+}
+
+type RgbaColor = {
+  readonly r: number;
+  readonly g: number;
+  readonly b: number;
+  readonly a: number;
+};
+
+interface SystemThemeCurrent {
+  readonly primary: RgbaColor;
+  readonly secondary: RgbaColor;
+  readonly accent: RgbaColor;
+  readonly error: RgbaColor;
+  readonly warning: RgbaColor;
+  readonly success: RgbaColor;
+  readonly info: RgbaColor;
+  readonly text: RgbaColor;
+  readonly textMuted: RgbaColor;
+  readonly selectedListItemText: RgbaColor;
+  readonly background: RgbaColor;
+  readonly backgroundPanel: RgbaColor;
+  readonly backgroundElement: RgbaColor;
+  readonly backgroundMenu: RgbaColor;
+  readonly border: RgbaColor;
+  readonly borderActive: RgbaColor;
+  readonly borderSubtle: RgbaColor;
+  readonly diffHighlightAdded: RgbaColor;
+  readonly diffHighlightRemoved: RgbaColor;
+  readonly diffAddedBg: RgbaColor;
+  readonly diffRemovedBg: RgbaColor;
+  readonly diffAddedLineNumberBg: RgbaColor;
+  readonly diffRemovedLineNumberBg: RgbaColor;
+}
+
+type SystemTheme = SystemThemeCurrent & {
+  _hasSelectedListItemText: boolean;
+};
+
+type SystemThemeColor = keyof SystemThemeCurrent;
+type HexColor = `#${string}`;
+type RefName = string;
+type Variant = {
+  dark: HexColor | RefName;
+  light: HexColor | RefName;
+};
+type ColorValue = HexColor | RefName | Variant | RgbaColor | number;
+
+type ThemeJson = {
+  defs?: Record<string, HexColor | RefName>;
+  theme: Omit<Record<SystemThemeColor, ColorValue>, "selectedListItemText" | "backgroundMenu"> & {
+    selectedListItemText?: ColorValue;
+    backgroundMenu?: ColorValue;
+  };
+};
+
+const ANSI_COLOR_FALLBACKS = [
+  "#000000",
+  "#800000",
+  "#008000",
+  "#808000",
+  "#000080",
+  "#800080",
+  "#008080",
+  "#c0c0c0",
+  "#808080",
+  "#ff0000",
+  "#00ff00",
+  "#ffff00",
+  "#0000ff",
+  "#ff00ff",
+  "#00ffff",
+  "#ffffff",
+] as const;
+
+function clampByte(value: number): number {
+  return Math.max(0, Math.min(255, Math.round(value)));
+}
+
+function isRgbaColor(value: unknown): value is RgbaColor {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "r" in value &&
+    "g" in value &&
+    "b" in value &&
+    "a" in value
+  );
+}
+
+function fromInts(r: number, g: number, b: number, a = 255): RgbaColor {
+  return {
+    r: clampByte(r),
+    g: clampByte(g),
+    b: clampByte(b),
+    a: clampByte(a),
+  };
+}
+
+function rgbaFromHex(hex: string): RgbaColor {
+  const normalized = hex.trim().replace(/^#/, "");
+  const expanded =
+    normalized.length === 3 || normalized.length === 4
+      ? normalized
+          .split("")
+          .map((value) => value + value)
+          .join("")
+      : normalized;
+
+  if (expanded.length !== 6 && expanded.length !== 8) {
+    throw new Error(`Unsupported color format: ${hex}`);
+  }
+
+  return fromInts(
+    Number.parseInt(expanded.slice(0, 2), 16),
+    Number.parseInt(expanded.slice(2, 4), 16),
+    Number.parseInt(expanded.slice(4, 6), 16),
+    expanded.length === 8 ? Number.parseInt(expanded.slice(6, 8), 16) : 255,
+  );
+}
+
+function formatHexChannel(value: number): string {
+  return value.toString(16).padStart(2, "0");
+}
+
+function rgbaToHex(color: RgbaColor): TuiColor {
+  const base = `#${formatHexChannel(color.r)}${formatHexChannel(color.g)}${formatHexChannel(color.b)}`;
+  return color.a === 255 ? base : `${base}${formatHexChannel(color.a)}`;
+}
+
+function luminanceFromColor(color: RgbaColor): number {
+  return (0.299 * color.r + 0.587 * color.g + 0.114 * color.b) / 255;
+}
+
+function systemBackgroundHex(colors: TerminalColors): string | null {
+  return colors.defaultBackground ?? colors.palette[0] ?? null;
+}
+
+function systemForegroundHex(colors: TerminalColors): string | null {
+  return colors.defaultForeground ?? colors.palette[7] ?? null;
+}
+
+export function isTuiThemeId(value: unknown): value is TuiThemeId {
+  return typeof value === "string" && (TUI_THEME_IDS as readonly string[]).includes(value);
+}
+
+export function normalizeTuiThemeId(value: unknown): TuiThemeId {
+  return isTuiThemeId(value) ? value : DEFAULT_TUI_THEME_ID;
+}
+
+export function hasUsableTerminalColors(
+  colors: TerminalColors | null | undefined,
+): colors is TerminalColors {
+  return Boolean(colors && systemBackgroundHex(colors) && systemForegroundHex(colors));
+}
+
+function luminanceFromHex(hex: string): number {
+  return luminanceFromColor(rgbaFromHex(hex));
+}
+
+function ansiCubeComponent(value: number): number {
+  return value === 0 ? 0 : value * 40 + 55;
+}
+
+function ansiToRgba(code: number): RgbaColor {
+  if (code < 16) {
+    return rgbaFromHex(ANSI_COLOR_FALLBACKS[code] ?? "#000000");
+  }
+  if (code < 232) {
+    const index = code - 16;
+    const b = index % 6;
+    const g = Math.floor(index / 6) % 6;
+    const r = Math.floor(index / 36);
+    return fromInts(ansiCubeComponent(r), ansiCubeComponent(g), ansiCubeComponent(b));
+  }
+  if (code < 256) {
+    const gray = (code - 232) * 10 + 8;
+    return fromInts(gray, gray, gray);
+  }
+  return fromInts(0, 0, 0);
+}
+
+function resolveSystemTheme(theme: ThemeJson, mode: TuiThemeMode): SystemTheme {
+  const defs = theme.defs ?? {};
+
+  function resolveColor(color: ColorValue, chain: string[] = []): RgbaColor {
+    if (isRgbaColor(color)) return color;
+    if (typeof color === "string") {
+      if (color === "transparent" || color === "none") return fromInts(0, 0, 0, 0);
+      if (color.startsWith("#")) return rgbaFromHex(color);
+      if (chain.includes(color)) {
+        throw new Error(`Circular color reference: ${[...chain, color].join(" -> ")}`);
+      }
+      const next = defs[color] ?? theme.theme[color as SystemThemeColor];
+      if (next === undefined) {
+        throw new Error(`Color reference "${color}" not found in defs or theme`);
+      }
+      return resolveColor(next, [...chain, color]);
+    }
+    if (typeof color === "number") {
+      return ansiToRgba(color);
+    }
+    return resolveColor(color[mode], chain);
+  }
+
+  const resolved = Object.fromEntries(
+    Object.entries(theme.theme)
+      .filter(([key]) => key !== "selectedListItemText" && key !== "backgroundMenu")
+      .map(([key, value]) => [key, resolveColor(value as ColorValue)]),
+  ) as Partial<Record<SystemThemeColor, RgbaColor>>;
+
+  const hasSelectedListItemText = theme.theme.selectedListItemText !== undefined;
+  if (hasSelectedListItemText) {
+    resolved.selectedListItemText = resolveColor(theme.theme.selectedListItemText!);
+  } else {
+    resolved.selectedListItemText = resolved.background!;
+  }
+
+  if (theme.theme.backgroundMenu !== undefined) {
+    resolved.backgroundMenu = resolveColor(theme.theme.backgroundMenu);
+  } else {
+    resolved.backgroundMenu = resolved.backgroundElement!;
+  }
+
+  return {
+    ...(resolved as SystemThemeCurrent),
+    _hasSelectedListItemText: hasSelectedListItemText,
+  };
+}
+
+function selectedForeground(theme: SystemTheme, bg?: RgbaColor): RgbaColor {
+  if (theme._hasSelectedListItemText) {
+    return theme.selectedListItemText;
+  }
+  if (theme.background.a === 0) {
+    return luminanceFromColor(bg ?? theme.primary) > 0.5
+      ? fromInts(0, 0, 0)
+      : fromInts(255, 255, 255);
+  }
+  return theme.background;
+}
+
+function tint(base: RgbaColor, overlay: RgbaColor, alpha: number): RgbaColor {
+  return fromInts(
+    base.r + (overlay.r - base.r) * alpha,
+    base.g + (overlay.g - base.g) * alpha,
+    base.b + (overlay.b - base.b) * alpha,
+    base.a,
+  );
+}
+
+function scaleChannels(bg: RgbaColor, luminance: number, nextLum: number): RgbaColor {
+  if (luminance === 0) {
+    return bg;
+  }
+
+  const ratio = nextLum / luminance;
+  return fromInts(bg.r * ratio, bg.g * ratio, bg.b * ratio, bg.a);
+}
+
+function generateGrayScale(bg: RgbaColor, isDark: boolean): Record<number, RgbaColor> {
+  const grays: Record<number, RgbaColor> = {};
+  const luminance = 0.299 * bg.r + 0.587 * bg.g + 0.114 * bg.b;
+
+  for (let index = 1; index <= 12; index++) {
+    const factor = index / 12;
+    let nextColor: RgbaColor;
+
+    if (isDark) {
+      if (luminance < 10) {
+        const gray = factor * 0.4 * 255;
+        nextColor = fromInts(gray, gray, gray);
+      } else {
+        const nextLum = luminance + (255 - luminance) * factor * 0.4;
+        nextColor = scaleChannels(bg, luminance, nextLum);
+      }
+    } else if (luminance > 245) {
+      const gray = 255 - factor * 0.4 * 255;
+      nextColor = fromInts(gray, gray, gray);
+    } else {
+      const nextLum = luminance * (1 - factor * 0.4);
+      nextColor = scaleChannels(bg, luminance, nextLum);
+    }
+
+    grays[index] = nextColor;
+  }
+
+  return grays;
+}
+
+function generateMutedTextColor(bg: RgbaColor, isDark: boolean): RgbaColor {
+  const luminance = 0.299 * bg.r + 0.587 * bg.g + 0.114 * bg.b;
+  const gray = isDark
+    ? luminance < 10
+      ? 180
+      : Math.min(Math.floor(160 + luminance * 0.3), 200)
+    : luminance > 245
+      ? 75
+      : Math.max(Math.floor(100 - (255 - luminance) * 0.2), 60);
+  return fromInts(gray, gray, gray);
+}
+
+function generateSystem(colors: TerminalColors, mode: TuiThemeMode): ThemeJson {
+  const backgroundHex = systemBackgroundHex(colors);
+  const foregroundHex = systemForegroundHex(colors);
+  if (!backgroundHex || !foregroundHex) {
+    throw new Error("Terminal palette is incomplete");
+  }
+
+  const bg = rgbaFromHex(backgroundHex);
+  const fg = rgbaFromHex(foregroundHex);
+  const transparent = fromInts(bg.r, bg.g, bg.b, 0);
+  const isDark = mode === "dark";
+  const grays = generateGrayScale(bg, isDark);
+  const textMuted = generateMutedTextColor(bg, isDark);
+  const gray = (index: number) => grays[index] ?? bg;
+  const colorAt = (index: number) => {
+    const value = colors.palette[index];
+    return value ? rgbaFromHex(value) : ansiToRgba(index);
+  };
+
+  const ansi = {
+    red: colorAt(1),
+    green: colorAt(2),
+    yellow: colorAt(3),
+    blue: colorAt(4),
+    magenta: colorAt(5),
+    cyan: colorAt(6),
+    redBright: colorAt(9),
+    greenBright: colorAt(10),
+  };
+
+  const diffAlpha = isDark ? 0.22 : 0.14;
+  return {
+    theme: {
+      primary: ansi.cyan,
+      secondary: ansi.magenta,
+      accent: ansi.cyan,
+      error: ansi.red,
+      warning: ansi.yellow,
+      success: ansi.green,
+      info: ansi.cyan,
+      text: fg,
+      textMuted,
+      selectedListItemText: bg,
+      background: transparent,
+      backgroundPanel: gray(2),
+      backgroundElement: gray(3),
+      backgroundMenu: gray(3),
+      borderSubtle: gray(6),
+      border: gray(7),
+      borderActive: gray(8),
+      diffHighlightAdded: ansi.greenBright,
+      diffHighlightRemoved: ansi.redBright,
+      diffAddedBg: tint(bg, ansi.green, diffAlpha),
+      diffRemovedBg: tint(bg, ansi.red, diffAlpha),
+      diffAddedLineNumberBg: tint(gray(3), ansi.green, diffAlpha),
+      diffRemovedLineNumberBg: tint(gray(3), ansi.red, diffAlpha),
+    },
+  };
+}
+
+export function resolveTerminalThemeMode(
+  colors: TerminalColors | null | undefined,
+): TuiThemeMode | null {
+  if (!hasUsableTerminalColors(colors)) return null;
+  return luminanceFromHex(systemBackgroundHex(colors)!) > 0.5 ? "light" : "dark";
+}
+
+function createTerminalMatchTheme(colors: TerminalColors, mode: TuiThemeMode): TuiTheme {
+  const resolved = resolveSystemTheme(generateSystem(colors, mode), mode);
+  const isDark = mode === "dark";
+  const toneAlpha = isDark ? 0.18 : 0.12;
+  const selectedText = selectedForeground(resolved, resolved.primary);
+
+  return {
+    id: TERMINAL_MATCH_THEME_ID,
+    mode,
+    palette: {
+      canvas: rgbaToHex(resolved.background),
+      sidebar: rgbaToHex(resolved.backgroundPanel),
+      main: rgbaToHex(resolved.background),
+      surface: rgbaToHex(resolved.backgroundPanel),
+      surfaceAlt: rgbaToHex(resolved.backgroundElement),
+      input: rgbaToHex(resolved.backgroundElement),
+      surfaceUser: rgbaToHex(resolved.backgroundPanel),
+      surfacePlan: rgbaToHex(
+        tint(resolved.backgroundPanel, resolved.secondary, isDark ? 0.14 : 0.1),
+      ),
+      surfaceWarn: rgbaToHex(tint(resolved.backgroundPanel, resolved.warning, isDark ? 0.16 : 0.1)),
+      surfaceInfo: rgbaToHex(tint(resolved.backgroundPanel, resolved.info, isDark ? 0.14 : 0.1)),
+      footer: rgbaToHex(resolved.background),
+      diff: rgbaToHex(resolved.backgroundPanel),
+      popup: rgbaToHex(resolved.backgroundMenu),
+      scrim: isDark ? "#00000099" : "#00000022",
+      border: rgbaToHex(resolved.border),
+      divider: rgbaToHex(resolved.borderSubtle),
+      control: "transparent",
+      controlHover: rgbaToHex(resolved.backgroundElement),
+      controlActive: rgbaToHex(resolved.backgroundElement),
+      controlActiveStrong: rgbaToHex(resolved.backgroundMenu),
+      controlInset: rgbaToHex(resolved.backgroundPanel),
+      controlInsetHover: rgbaToHex(resolved.backgroundElement),
+      composerPanel: rgbaToHex(resolved.backgroundElement),
+      composerBorder: rgbaToHex(resolved.primary),
+      composerBorderMuted: rgbaToHex(resolved.borderSubtle),
+      composerSend: rgbaToHex(resolved.primary),
+      composerSendHover: rgbaToHex(resolved.accent),
+      composerStop: rgbaToHex(resolved.error),
+      composerStopHover: rgbaToHex(resolved.diffHighlightRemoved),
+      accent: rgbaToHex(resolved.accent),
+      cursor: rgbaToHex(resolved.text),
+      selection: rgbaToHex(resolved.primary),
+      selectionActive: rgbaToHex(resolved.accent),
+      text: rgbaToHex(resolved.text),
+      muted: rgbaToHex(resolved.textMuted),
+      subtle: rgbaToHex(resolved.borderActive),
+      success: rgbaToHex(resolved.success),
+      info: rgbaToHex(resolved.info),
+      warning: rgbaToHex(resolved.warning),
+      claude: rgbaToHex(resolved.secondary),
+      macRed: "#ff5f57",
+      macYellow: "#febc2e",
+      macGreen: "#28c840",
+    },
+    attachmentPillTones: [
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.primary, toneAlpha)),
+        textColor: rgbaToHex(resolved.primary),
+      },
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.secondary, toneAlpha)),
+        textColor: rgbaToHex(resolved.secondary),
+      },
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.warning, toneAlpha)),
+        textColor: rgbaToHex(resolved.warning),
+      },
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.error, toneAlpha)),
+        textColor: rgbaToHex(resolved.error),
+      },
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.success, toneAlpha)),
+        textColor: rgbaToHex(resolved.success),
+      },
+      {
+        backgroundColor: rgbaToHex(tint(resolved.backgroundElement, resolved.info, toneAlpha)),
+        textColor: rgbaToHex(resolved.info),
+      },
+    ],
+    codeBlock: {
+      background: rgbaToHex(resolved.backgroundElement),
+      language: rgbaToHex(resolved.textMuted),
+      copyIcon: rgbaToHex(resolved.textMuted),
+    },
+    status: {
+      awaitingInput: rgbaToHex(resolved.primary),
+      working: rgbaToHex(resolved.info),
+      planReady: rgbaToHex(resolved.secondary),
+      pulse: rgbaToHex(resolved.accent),
+    },
+    diffViewer: {
+      addedBg: rgbaToHex(resolved.diffAddedLineNumberBg),
+      removedBg: rgbaToHex(resolved.diffRemovedLineNumberBg),
+      addedContentBg: rgbaToHex(resolved.diffAddedBg),
+      removedContentBg: rgbaToHex(resolved.diffRemovedBg),
+      addedSignColor: rgbaToHex(resolved.diffHighlightAdded),
+      removedSignColor: rgbaToHex(resolved.diffHighlightRemoved),
+    },
+    colors: {
+      workEntryErrorAccent: rgbaToHex(resolved.diffHighlightRemoved),
+      destructiveIcon: rgbaToHex(resolved.error),
+      controlKnob: rgbaToHex(selectedText),
+      primaryButtonText: rgbaToHex(selectedText),
+      sendDotIdle: rgbaToHex(resolved.textMuted),
+      sendDotActive: rgbaToHex(selectedText),
+      selectedText: rgbaToHex(selectedText),
+    },
+  };
+}
+
+function terminalColorsSignature(colors: TerminalColors | null | undefined): string {
+  if (!colors) return "none";
+  return [
+    colors.defaultBackground ?? "",
+    colors.defaultForeground ?? "",
+    ...colors.palette.map((value) => value ?? ""),
+  ].join("|");
+}
+
+export function resolveTuiThemeMode(
+  theme: AppTheme | undefined,
+  systemMode: TuiThemeMode | null = null,
+): TuiThemeMode {
+  if (theme === "light") return "light";
+  if (theme === "dark") return "dark";
+  return systemMode ?? "dark";
+}
+
+const THEME_CACHE = new Map<string, TuiTheme>([
+  [`${DEFAULT_TUI_THEME_ID}:dark`, DEFAULT_DARK_THEME],
+  [`${DEFAULT_TUI_THEME_ID}:light`, DEFAULT_LIGHT_THEME],
+]);
+
+export function resolveTuiTheme(
+  theme: AppTheme | undefined,
+  themeId: TuiThemeId = DEFAULT_TUI_THEME_ID,
+  options: ResolveTuiThemeOptions = {},
+): TuiTheme {
+  const mode = resolveTuiThemeMode(theme, options.systemMode ?? null);
+  const cacheKey =
+    themeId === TERMINAL_MATCH_THEME_ID
+      ? `${themeId}:${mode}:${terminalColorsSignature(options.terminalColors)}`
+      : `${themeId}:${mode}`;
+  const cached = THEME_CACHE.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
+  if (themeId === TERMINAL_MATCH_THEME_ID) {
+    const fallback = defaultThemeForMode(mode);
+    if (!hasUsableTerminalColors(options.terminalColors)) {
+      THEME_CACHE.set(cacheKey, fallback);
+      return fallback;
+    }
+
+    const resolved = createTerminalMatchTheme(options.terminalColors, mode);
+    THEME_CACHE.set(cacheKey, resolved);
+    return resolved;
+  }
+
+  return defaultThemeForMode(mode);
+}
+
+export function colorToHex(color: TuiColor): string {
+  return color;
+}

--- a/apps/tui/src/ui.tsx
+++ b/apps/tui/src/ui.tsx
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type {
+  CliRenderer,
   InputRenderable,
   PasteEvent,
   ScrollBoxRenderable,
@@ -10,6 +11,7 @@ import type {
   TextareaRenderable,
 } from "@opentui/core";
 import {
+  CliRenderEvents,
   decodePasteBytes,
   pathToFiletype,
   RGBA,
@@ -132,6 +134,13 @@ import {
 } from "./messageMarkdown";
 import { openExternalUrl } from "./openExternal";
 import { type TuiPrefs, readPrefs, writePrefs } from "./prefs";
+import {
+  normalizeRendererThemeMode,
+  resolveTerminalPalette,
+  shouldListenForRendererThemeChanges,
+  shouldResolveTerminalPalette,
+  shouldTrackSystemThemeMode,
+} from "./rendererTheme";
 import { resolveTuiResponsiveLayout, TUI_SIDEBAR_WIDTH } from "./responsiveLayout";
 import { resolveAttachedServerConnection, startServerSupervisor } from "./serverSupervisor";
 import { createCoalescedRefreshRunner } from "./snapshotRefresh";
@@ -142,6 +151,20 @@ import {
   resolveTerminalImageSupport,
   type TerminalImageSupport,
 } from "./terminalImages";
+import {
+  DEFAULT_TUI_THEME,
+  DEFAULT_TUI_THEME_ID,
+  TUI_THEME_IDS,
+  TUI_THEME_LABELS,
+  normalizeTuiThemeId,
+  resolveTerminalThemeMode,
+  resolveTuiTheme,
+  type TuiColor,
+  type TuiPalette,
+  type TerminalColors,
+  type TuiThemeId,
+  type TuiThemeMode,
+} from "./theme";
 import {
   buildMultiSelectContextMenuItems,
   buildProjectRemovalConfirmSteps,
@@ -193,6 +216,7 @@ type OverlayMenu =
   | "composer-branch";
 type SettingsSelectKind =
   | "theme"
+  | "theme-preset"
   | "timestamp-format"
   | "thread-env"
   | "git-model"
@@ -226,6 +250,25 @@ type PendingSendPreview = {
   attachments: ComposerImageAttachment[];
   createdAt: string;
   visibleUntil: number;
+};
+type RendererSelection = {
+  getSelectedText(): string;
+};
+type TerminalRenderer = {
+  capabilities?: {
+    kitty_graphics?: boolean;
+    sixel?: boolean;
+  } | null;
+  resolution?: {
+    width: number;
+    height: number;
+  } | null;
+  console?: TerminalConsole | null;
+  getSelection?: () => RendererSelection | null;
+  clearSelection?: () => void;
+  on?: (event: string | symbol, handler: (...args: unknown[]) => void) => void;
+  off?: (event: string | symbol, handler: (...args: unknown[]) => void) => void;
+  writeOut?: (chunk: string) => void;
 };
 type DraftThreadState = {
   id: string;
@@ -431,101 +474,10 @@ type InstallProviderSettings = {
   homePlaceholder?: string;
   homeDescription?: string;
 };
-const DARK_PALETTE = {
-  canvas: "#171717",
-  sidebar: "#151515",
-  main: "#171717",
-  surface: "#1b1b1b",
-  surfaceAlt: "#1f1f1f",
-  input: "#111111",
-  surfaceUser: "#202020",
-  surfacePlan: "#1f221c",
-  surfaceWarn: "#262016",
-  surfaceInfo: "#1d2026",
-  footer: "#171717",
-  diff: "#1b1b1b",
-  popup: "#1c1c1c",
-  scrim: "#00000099",
-  border: "#252525",
-  divider: "#2d2d2d",
-  control: "transparent",
-  controlHover: "#202020",
-  controlActive: "#292929",
-  controlActiveStrong: "#1e1e1e",
-  controlInset: "#141414",
-  controlInsetHover: "#1a1a1a",
-  composerPanel: "#1a1a1a",
-  composerBorder: "#2a3f95",
-  composerBorderMuted: "#313131",
-  composerSend: "#2f438e",
-  composerSendHover: "#3c57ba",
-  composerStop: "#dc2626",
-  composerStopHover: "#ef4444",
-  accent: "#7c87ff",
-  cursor: "#d4d4d4",
-  selection: "#1f4f95",
-  selectionActive: "#2b61b0",
-  text: "#f5f5f5",
-  muted: "#a3a3a3",
-  subtle: "#737373",
-  success: "#10b981",
-  info: "#3b82f6",
-  warning: "#f59e0b",
-  claude: "#d97757",
-  macRed: "#ff5f57",
-  macYellow: "#febc2e",
-  macGreen: "#28c840",
-};
+const PALETTE: TuiPalette = { ...DEFAULT_TUI_THEME.palette };
+let ACTIVE_TUI_THEME = DEFAULT_TUI_THEME;
 
-const LIGHT_PALETTE = {
-  canvas: "#f5f5f5",
-  sidebar: "#eeeeee",
-  main: "#f7f7f7",
-  surface: "#ffffff",
-  surfaceAlt: "#f1f1f1",
-  input: "#ffffff",
-  surfaceUser: "#ececec",
-  surfacePlan: "#eef6ec",
-  surfaceWarn: "#fff5e6",
-  surfaceInfo: "#eef4ff",
-  footer: "#f7f7f7",
-  diff: "#fafafa",
-  popup: "#ffffff",
-  scrim: "#00000022",
-  border: "#dddddd",
-  divider: "#d8d8d8",
-  control: "transparent",
-  controlHover: "#ebebeb",
-  controlActive: "#e2e2e2",
-  controlActiveStrong: "#cdcdcd",
-  controlInset: "#e7e7e7",
-  controlInsetHover: "#dddddd",
-  composerPanel: "#ffffff",
-  composerBorder: "#0891b2",
-  composerBorderMuted: "#d0d0d0",
-  composerSend: "#60a5fa",
-  composerSendHover: "#3b82f6",
-  composerStop: "#dc2626",
-  composerStopHover: "#ef4444",
-  accent: "#0891b2",
-  cursor: "#a3a3a3",
-  selection: "#dbeafe",
-  selectionActive: "#bfdbfe",
-  text: "#171717",
-  muted: "#666666",
-  subtle: "#8a8a8a",
-  success: "#059669",
-  info: "#2563eb",
-  warning: "#d97706",
-  claude: "#c96d4d",
-  macRed: "#ff5f57",
-  macYellow: "#febc2e",
-  macGreen: "#28c840",
-};
-
-const PALETTE = { ...DARK_PALETTE };
-
-function themedScrollboxStyle(backgroundColor: string) {
+function themedScrollboxStyle(backgroundColor: TuiColor) {
   return {
     backgroundColor,
     rootOptions: {
@@ -551,6 +503,7 @@ function themedScrollboxStyle(backgroundColor: string) {
 
 const APP_VERSION = packageJson.version ?? "0.0.0";
 const THEME_OPTIONS: readonly AppTheme[] = ["system", "light", "dark"];
+const TUI_THEME_OPTIONS = TUI_THEME_IDS;
 const TIMESTAMP_FORMAT_OPTIONS: readonly TimestampFormat[] = ["locale", "12-hour", "24-hour"];
 const TIMESTAMP_FORMAT_LABELS: Record<TimestampFormat, string> = {
   locale: "System default",
@@ -576,42 +529,47 @@ const INSTALL_PROVIDER_SETTINGS: readonly InstallProviderSettings[] = [
     binaryDescription: "Leave blank to use claude from your PATH.",
   },
 ] as const;
-function buildMessageMarkdownSyntax(palette: typeof PALETTE) {
+
+function toRendererColor(color: TuiColor): RGBA {
+  return RGBA.fromHex(color);
+}
+
+function buildMessageMarkdownSyntax(palette: TuiPalette) {
   return SyntaxStyle.fromStyles({
-    keyword: { fg: RGBA.fromHex(palette.warning), bold: true },
+    keyword: { fg: toRendererColor(palette.warning), bold: true },
     string: { fg: RGBA.fromHex("#9bd1ff") },
-    comment: { fg: RGBA.fromHex(palette.subtle), italic: true },
+    comment: { fg: toRendererColor(palette.subtle), italic: true },
     number: { fg: RGBA.fromHex("#8cc8ff") },
-    function: { fg: RGBA.fromHex(palette.accent) },
+    function: { fg: toRendererColor(palette.accent) },
     type: { fg: RGBA.fromHex("#f7b267") },
-    operator: { fg: RGBA.fromHex(palette.warning) },
-    variable: { fg: RGBA.fromHex(palette.text) },
+    operator: { fg: toRendererColor(palette.warning) },
+    variable: { fg: toRendererColor(palette.text) },
     property: { fg: RGBA.fromHex("#8cc8ff") },
-    "punctuation.bracket": { fg: RGBA.fromHex(palette.text) },
-    "punctuation.delimiter": { fg: RGBA.fromHex(palette.muted) },
-    "punctuation.special": { fg: RGBA.fromHex(palette.subtle) },
-    "markup.heading": { fg: RGBA.fromHex(palette.text), bold: true },
-    "markup.heading.1": { fg: RGBA.fromHex(palette.text), bold: true, underline: true },
-    "markup.heading.2": { fg: RGBA.fromHex(palette.text), bold: true },
-    "markup.heading.3": { fg: RGBA.fromHex(palette.text), bold: true },
-    "markup.bold": { fg: RGBA.fromHex(palette.text), bold: true },
-    "markup.strong": { fg: RGBA.fromHex(palette.text), bold: true },
-    "markup.italic": { fg: RGBA.fromHex(palette.text), italic: true },
-    "markup.list": { fg: RGBA.fromHex(palette.muted) },
-    "markup.quote": { fg: RGBA.fromHex(palette.muted), italic: true },
-    "markup.raw": { fg: RGBA.fromHex("#9bd1ff"), bg: RGBA.fromHex(palette.surfaceAlt) },
-    "markup.raw.block": { fg: RGBA.fromHex("#9bd1ff"), bg: RGBA.fromHex(palette.surfaceAlt) },
-    "markup.raw.inline": { fg: RGBA.fromHex("#9bd1ff"), bg: RGBA.fromHex(palette.surfaceAlt) },
+    "punctuation.bracket": { fg: toRendererColor(palette.text) },
+    "punctuation.delimiter": { fg: toRendererColor(palette.muted) },
+    "punctuation.special": { fg: toRendererColor(palette.subtle) },
+    "markup.heading": { fg: toRendererColor(palette.text), bold: true },
+    "markup.heading.1": { fg: toRendererColor(palette.text), bold: true, underline: true },
+    "markup.heading.2": { fg: toRendererColor(palette.text), bold: true },
+    "markup.heading.3": { fg: toRendererColor(palette.text), bold: true },
+    "markup.bold": { fg: toRendererColor(palette.text), bold: true },
+    "markup.strong": { fg: toRendererColor(palette.text), bold: true },
+    "markup.italic": { fg: toRendererColor(palette.text), italic: true },
+    "markup.list": { fg: toRendererColor(palette.muted) },
+    "markup.quote": { fg: toRendererColor(palette.muted), italic: true },
+    "markup.raw": { fg: RGBA.fromHex("#9bd1ff"), bg: toRendererColor(palette.surfaceAlt) },
+    "markup.raw.block": { fg: RGBA.fromHex("#9bd1ff"), bg: toRendererColor(palette.surfaceAlt) },
+    "markup.raw.inline": { fg: RGBA.fromHex("#9bd1ff"), bg: toRendererColor(palette.surfaceAlt) },
     "markup.link": { fg: RGBA.fromHex("#7fb7ff"), underline: true },
     "markup.link.label": { fg: RGBA.fromHex("#b7d7ff"), underline: true },
     "markup.link.url": { fg: RGBA.fromHex("#7fb7ff"), underline: true },
-    label: { fg: RGBA.fromHex(palette.success) },
-    conceal: { fg: RGBA.fromHex(palette.subtle) },
-    default: { fg: RGBA.fromHex(palette.text) },
+    label: { fg: toRendererColor(palette.success) },
+    conceal: { fg: toRendererColor(palette.subtle) },
+    default: { fg: toRendererColor(palette.text) },
   });
 }
 
-function buildDiffSyntax(palette: typeof PALETTE) {
+function buildDiffSyntax(palette: TuiPalette) {
   return SyntaxStyle.fromStyles({
     keyword: { fg: RGBA.fromHex("#ff7b72"), bold: true },
     string: { fg: RGBA.fromHex("#a5d6ff") },
@@ -620,7 +578,7 @@ function buildDiffSyntax(palette: typeof PALETTE) {
     function: { fg: RGBA.fromHex("#d2a8ff") },
     type: { fg: RGBA.fromHex("#ffa657") },
     operator: { fg: RGBA.fromHex("#ffb86b") },
-    variable: { fg: RGBA.fromHex(palette.text) },
+    variable: { fg: toRendererColor(palette.text) },
     property: { fg: RGBA.fromHex("#79c0ff") },
     constant: { fg: RGBA.fromHex("#79c0ff") },
     tag: { fg: RGBA.fromHex("#7ee787") },
@@ -628,11 +586,11 @@ function buildDiffSyntax(palette: typeof PALETTE) {
     "punctuation.bracket": { fg: RGBA.fromHex("#c9d1d9") },
     "punctuation.delimiter": { fg: RGBA.fromHex("#c9d1d9") },
     "punctuation.special": { fg: RGBA.fromHex("#8b949e") },
-    default: { fg: RGBA.fromHex(palette.text) },
+    default: { fg: toRendererColor(palette.text) },
   });
 }
 
-function buildCodeBlockSyntax(_palette: typeof PALETTE) {
+function buildCodeBlockSyntax(_palette: TuiPalette) {
   return SyntaxStyle.fromStyles({
     keyword: { fg: RGBA.fromHex("#c9b37e"), bold: true },
     string: { fg: RGBA.fromHex("#9ab37f") },
@@ -822,7 +780,7 @@ function providerPickerIcon(provider: string): string {
   return "󰚩";
 }
 
-function providerColor(provider: ProviderKind | string | null | undefined): string {
+function providerColor(provider: ProviderKind | string | null | undefined): TuiColor {
   return provider === "claudeAgent" ? PALETTE.claude : PALETTE.muted;
 }
 
@@ -1301,17 +1259,9 @@ function mergeChatAttachments<T extends ComposerImageAttachment>(
   return merged;
 }
 
-const ATTACHMENT_PILL_TONES = [
-  { backgroundColor: "#1d2026", textColor: "#3b82f6" },
-  { backgroundColor: "#241b2f", textColor: "#a78bfa" },
-  { backgroundColor: "#2a2417", textColor: "#facc15" },
-  { backgroundColor: "#2a1b1b", textColor: "#f87171" },
-  { backgroundColor: "#1c2721", textColor: "#34d399" },
-  { backgroundColor: "#272019", textColor: "#fb923c" },
-];
-
 function resolveAttachmentPillTone(index: number) {
-  return ATTACHMENT_PILL_TONES[index % ATTACHMENT_PILL_TONES.length] ?? ATTACHMENT_PILL_TONES[0]!;
+  const tones = ACTIVE_TUI_THEME.attachmentPillTones;
+  return tones[index % tones.length] ?? tones[0]!;
 }
 
 function resolveHttpOriginFromWsUrl(rawUrl: string): string | null {
@@ -1485,7 +1435,7 @@ export function MessageMarkdown({
   onCopyCodeBlock,
 }: {
   content: string;
-  color?: string;
+  color?: TuiColor;
   fillWidth?: boolean;
   onCopyCodeBlock?: (value: string) => void;
 }) {
@@ -1567,7 +1517,7 @@ export function MessageMarkdown({
                 width: "auto",
                 minWidth: 0,
                 flexDirection: "column",
-                backgroundColor: "#101010",
+                backgroundColor: ACTIVE_TUI_THEME.codeBlock.background,
                 paddingLeft: 1,
                 paddingRight: 1,
                 paddingTop: 0,
@@ -1575,7 +1525,10 @@ export function MessageMarkdown({
               }}
             >
               {segment.language ? (
-                <text content={segment.language} style={{ fg: "#8a8a8a" }} />
+                <text
+                  content={segment.language}
+                  style={{ fg: ACTIVE_TUI_THEME.codeBlock.language }}
+                />
               ) : null}
               <code
                 content={displayedCode || " "}
@@ -1613,7 +1566,7 @@ export function MessageMarkdown({
                       alignItems: "center",
                     }}
                   >
-                    <text content="󰆏" style={{ fg: "#9a9a9a" }} />
+                    <text content="󰆏" style={{ fg: ACTIVE_TUI_THEME.codeBlock.copyIcon }} />
                   </box>
                 </box>
               ) : null}
@@ -1788,8 +1741,8 @@ function workEntryPrefix(entry: Extract<TimelineEntry, { kind: "work" }>["entry"
   return resolveWorkEntryIcon(entry);
 }
 
-function workEntryAccent(entry: Extract<TimelineEntry, { kind: "work" }>["entry"]): string {
-  if (entry.tone === "error") return "#fda4af";
+function workEntryAccent(entry: Extract<TimelineEntry, { kind: "work" }>["entry"]): TuiColor {
+  if (entry.tone === "error") return ACTIVE_TUI_THEME.colors.workEntryErrorAccent;
   if (entry.requestKind === "command" || entry.command) return PALETTE.text;
   if (entry.requestKind === "file-change" || (entry.changedFiles?.length ?? 0) > 0) {
     return PALETTE.info;
@@ -1802,21 +1755,21 @@ function workEntryAccent(entry: Extract<TimelineEntry, { kind: "work" }>["entry"
 
 type ThreadSidebarStatus = {
   label: ThreadStatusPill["label"];
-  dotColor: string;
+  dotColor: TuiColor;
   pulse: boolean;
 };
 
-function resolveThreadStatusColor(label: ThreadStatusPill["label"]): string {
+function resolveThreadStatusColor(label: ThreadStatusPill["label"]): TuiColor {
   switch (label) {
     case "Pending Approval":
       return PALETTE.warning;
     case "Awaiting Input":
-      return "#818cf8";
+      return ACTIVE_TUI_THEME.status.awaitingInput;
     case "Working":
     case "Connecting":
-      return "#7dd3fc";
+      return ACTIVE_TUI_THEME.status.working;
     case "Plan Ready":
-      return "#a78bfa";
+      return ACTIVE_TUI_THEME.status.planReady;
     case "Completed":
       return PALETTE.success;
   }
@@ -1857,9 +1810,9 @@ function threadStatus(
   };
 }
 
-function resolveThreadStatusDotColor(status: ThreadSidebarStatus, tick: number): string {
+function resolveThreadStatusDotColor(status: ThreadSidebarStatus, tick: number): TuiColor {
   if (!status.pulse) return status.dotColor;
-  return tick % 2 === 0 ? status.dotColor : "#3b82f6";
+  return tick % 2 === 0 ? status.dotColor : ACTIVE_TUI_THEME.status.pulse;
 }
 
 function approvalHint(approval: ReturnType<typeof derivePendingApprovals>[number]): string {
@@ -1954,8 +1907,6 @@ const COMPOSER_TEXTAREA_MAX_HEIGHT = 8;
 const COMPOSER_PATH_SUGGESTION_MAX_ITEMS = 5;
 const SEND_ANIMATION_INTERVAL_MS = 90;
 const SEND_PLACEHOLDER_MIN_DURATION_MS = 650;
-const SEND_DOT_IDLE_COLOR = "#6b7280";
-const SEND_DOT_ACTIVE_COLOR = "#d1d5db";
 const SIDEBAR_STATUS_PULSE_INTERVAL_MS = 260;
 const SIDEBAR_THREAD_TITLE_WIDTH =
   TUI_SIDEBAR_WIDTH -
@@ -2108,12 +2059,15 @@ function WindowDots() {
 
 function renderAnimatedSendDots(
   tick: number,
-): Array<{ key: string; character: string; color: string }> {
+): Array<{ key: string; character: string; color: TuiColor }> {
   const activeDot = tick % 3;
   return Array.from({ length: 3 }, (_, index) => ({
     key: `send-dot-${index}`,
     character: "•",
-    color: index === activeDot ? SEND_DOT_ACTIVE_COLOR : SEND_DOT_IDLE_COLOR,
+    color:
+      index === activeDot
+        ? ACTIVE_TUI_THEME.colors.sendDotActive
+        : ACTIVE_TUI_THEME.colors.sendDotIdle,
   }));
 }
 
@@ -2155,7 +2109,7 @@ function IconButton(props: {
   icon: string;
   active?: boolean;
   accent?: boolean;
-  iconColor?: string;
+  iconColor?: TuiColor;
   width?: number;
   justifyContent?: "center" | "flex-start" | "flex-end";
   onPress: (event?: SidebarMouseEvent) => void;
@@ -2170,7 +2124,11 @@ function IconButton(props: {
       : hovered
         ? PALETTE.controlHover
         : PALETTE.control;
-  const foreground = props.accent ? PALETTE.text : props.active ? PALETTE.text : PALETTE.muted;
+  const foreground = props.accent
+    ? ACTIVE_TUI_THEME.colors.selectedText
+    : props.active
+      ? PALETTE.text
+      : PALETTE.muted;
 
   return (
     <box
@@ -2203,7 +2161,7 @@ function ToolbarButton(props: {
   label?: string | undefined;
   active?: boolean;
   disabled?: boolean;
-  iconColor?: string;
+  iconColor?: TuiColor;
   marginRight?: number;
   compact?: boolean;
   surface?: "default" | "inset";
@@ -2282,7 +2240,7 @@ function TogglePill(props: { checked: boolean; onPress: () => void; disabled?: b
       : hovered
         ? PALETTE.controlHover
         : PALETTE.controlActive;
-  const knobColor = props.disabled ? PALETTE.subtle : "#f5f5f5";
+  const knobColor = props.disabled ? PALETTE.subtle : ACTIVE_TUI_THEME.colors.controlKnob;
   const edgeColor = background;
 
   return (
@@ -2325,7 +2283,7 @@ function SidebarRow(props: {
   selected?: boolean;
   compact?: boolean;
   suppressHighlight?: boolean;
-  activeBackgroundColor?: string;
+  activeBackgroundColor?: TuiColor;
   onPress?: (event: SidebarMouseEvent) => void;
   onSecondaryPress?: (event: SidebarMouseEvent) => void;
   children: React.ReactNode;
@@ -2381,7 +2339,7 @@ function PopupRow(props: {
   label: string;
   active?: boolean;
   disabled?: boolean;
-  iconColor?: string;
+  iconColor?: TuiColor;
   trailingLabel?: string;
   onHover?: () => void;
   onPress: () => void;
@@ -2642,7 +2600,7 @@ function ComposerSendButton(props: {
       : hovered
         ? PALETTE.composerSendHover
         : PALETTE.composerSend;
-  const foreground = props.disabled ? PALETTE.subtle : "#f5f5f5";
+  const foreground = props.disabled ? PALETTE.subtle : ACTIVE_TUI_THEME.colors.primaryButtonText;
 
   return (
     <box
@@ -2676,32 +2634,20 @@ export function App({
   renderer: _renderer,
   interruptRequestToken = 0,
   onRequestExit,
+  initialAppSettings,
+  initialTuiThemeId,
+  initialSystemThemeMode,
+  initialTerminalThemeColors,
 }: {
-  renderer: {
-    destroy: () => void;
-    setBackgroundColor?: (color: string) => void;
-    setCursorColor?: (color: RGBA) => void;
-    setCursorStyle?: (options: {
-      style: "block" | "line" | "underline";
-      blinking?: boolean;
-    }) => void;
-  };
+  renderer: CliRenderer;
   interruptRequestToken?: number;
   onRequestExit?: () => void;
+  initialAppSettings?: AppSettings;
+  initialTuiThemeId?: TuiThemeId;
+  initialSystemThemeMode?: TuiThemeMode | null;
+  initialTerminalThemeColors?: TerminalColors | null;
 }) {
-  const terminalRenderer = _renderer as {
-    capabilities?: {
-      kitty_graphics?: boolean;
-      sixel?: boolean;
-    } | null;
-    resolution?: { width: number; height: number } | null;
-    writeOut?: (chunk: string) => void;
-    on?: (event: string, handler: (...args: unknown[]) => void) => void;
-    off?: (event: string, handler: (...args: unknown[]) => void) => void;
-    console?: TerminalConsole;
-    getSelection?: () => { getSelectedText: () => string } | null;
-    clearSelection?: () => void;
-  };
+  const terminalRenderer = _renderer as unknown as TerminalRenderer;
   const paths = useMemo(() => resolveTuiPaths(), []);
   const logger = useMemo(() => createT1Logger(paths.logPath), [paths.logPath]);
   const [api, setApi] = useState<T1Api | null>(null);
@@ -2798,7 +2744,18 @@ export function App({
   const [locallyVisitedThreads, setLocallyVisitedThreads] = useState<LocalThreadVisitedState>({});
   const [selectedThreadIds, setSelectedThreadIds] = useState<ReadonlySet<string>>(() => new Set());
   const [selectionAnchorThreadId, setSelectionAnchorThreadId] = useState<string | null>(null);
-  const [appSettings, setAppSettings] = useState<AppSettings>(DEFAULT_APP_SETTINGS);
+  const [appSettings, setAppSettings] = useState<AppSettings>(() =>
+    normalizeAppSettings({ ...DEFAULT_APP_SETTINGS, ...initialAppSettings }),
+  );
+  const [tuiThemeId, setTuiThemeId] = useState<TuiThemeId>(
+    () => initialTuiThemeId ?? DEFAULT_TUI_THEME_ID,
+  );
+  const [systemThemeMode, setSystemThemeMode] = useState<TuiThemeMode | null>(
+    () => initialSystemThemeMode ?? normalizeRendererThemeMode(_renderer.themeMode),
+  );
+  const [terminalThemeColors, setTerminalThemeColors] = useState<TerminalColors | null>(
+    initialTerminalThemeColors ?? null,
+  );
   const [respondingRequestIds, setRespondingRequestIds] = useState<readonly ApprovalRequestId[]>(
     [],
   );
@@ -2846,13 +2803,21 @@ export function App({
   const updateAppSettings = useCallback((patch: Partial<AppSettings>) => {
     setAppSettings((current) => normalizeAppSettings({ ...current, ...patch }));
   }, []);
-  const resolvedTheme =
-    appSettings.theme === "light" ? "light" : appSettings.theme === "dark" ? "dark" : "dark";
-  const palette = resolvedTheme === "light" ? LIGHT_PALETTE : DARK_PALETTE;
-  Object.assign(PALETTE, palette);
-  MESSAGE_MARKDOWN_SYNTAX = buildMessageMarkdownSyntax(PALETTE);
-  DIFF_SYNTAX = buildDiffSyntax(PALETTE);
-  CODE_BLOCK_SYNTAX = buildCodeBlockSyntax(PALETTE);
+  const tracksSystemThemeMode = shouldTrackSystemThemeMode(appSettings.theme);
+  const usesTerminalPalette = shouldResolveTerminalPalette(tuiThemeId);
+  const listensForRendererThemeChanges = shouldListenForRendererThemeChanges(
+    appSettings.theme,
+    tuiThemeId,
+  );
+  const activeTheme = resolveTuiTheme(appSettings.theme, tuiThemeId, {
+    systemMode: systemThemeMode,
+    terminalColors: terminalThemeColors,
+  });
+  ACTIVE_TUI_THEME = activeTheme;
+  Object.assign(PALETTE, activeTheme.palette);
+  MESSAGE_MARKDOWN_SYNTAX = buildMessageMarkdownSyntax(activeTheme.palette);
+  DIFF_SYNTAX = buildDiffSyntax(activeTheme.palette);
+  CODE_BLOCK_SYNTAX = buildCodeBlockSyntax(activeTheme.palette);
 
   useEffect(() => {
     draftThreadsByProjectIdRef.current = draftThreadsByProjectId;
@@ -2863,13 +2828,49 @@ export function App({
   }, [composerDraftsByThreadId]);
 
   useEffect(() => {
-    _renderer.setBackgroundColor?.(PALETTE.canvas);
-    _renderer.setCursorColor?.(RGBA.fromHex(PALETTE.cursor));
+    _renderer.setBackgroundColor?.(toRendererColor(PALETTE.canvas));
+    _renderer.setCursorColor?.(toRendererColor(PALETTE.cursor));
     _renderer.setCursorStyle?.({
       style: "block",
       blinking: false,
     });
-  }, [_renderer, resolvedTheme]);
+  }, [_renderer, activeTheme.palette.canvas, activeTheme.palette.cursor]);
+
+  useEffect(() => {
+    let disposed = false;
+    const applyRendererThemeState = async (clearPaletteCache = false) => {
+      const nextTerminalColors = usesTerminalPalette
+        ? (await resolveTerminalPalette(_renderer, { clearCache: clearPaletteCache })).colors
+        : null;
+      if (disposed) return;
+      setTerminalThemeColors(nextTerminalColors);
+      setSystemThemeMode(
+        resolveTerminalThemeMode(nextTerminalColors) ??
+          normalizeRendererThemeMode(_renderer.themeMode),
+      );
+    };
+
+    void applyRendererThemeState(false);
+    if (!listensForRendererThemeChanges) {
+      return () => {
+        disposed = true;
+      };
+    }
+
+    const handleThemeMode = (nextMode: unknown) => {
+      const normalizedMode = normalizeRendererThemeMode(nextMode);
+      if (tracksSystemThemeMode && normalizedMode) {
+        setSystemThemeMode(normalizedMode);
+      }
+      void applyRendererThemeState(usesTerminalPalette);
+    };
+
+    _renderer.on?.(CliRenderEvents.THEME_MODE, handleThemeMode);
+    return () => {
+      disposed = true;
+      _renderer.off?.(CliRenderEvents.THEME_MODE, handleThemeMode);
+    };
+  }, [_renderer, listensForRendererThemeChanges, tracksSystemThemeMode, usesTerminalPalette]);
 
   useEffect(() => {
     setTerminalImageSupport(resolveTerminalImageSupport(terminalRenderer));
@@ -2963,6 +2964,7 @@ export function App({
           setMainView(prefs.mainView);
           setFocusArea("settings");
         }
+        setTuiThemeId(normalizeTuiThemeId(prefs.tuiThemeId));
         if (prefs.appSettings) {
           setAppSettings(normalizeAppSettings({ ...DEFAULT_APP_SETTINGS, ...prefs.appSettings }));
           setOpenInstallProviders({
@@ -3161,6 +3163,7 @@ export function App({
       draftInteractionMode,
       diffOpen,
       diffView,
+      ...(tuiThemeId !== DEFAULT_TUI_THEME_ID ? { tuiThemeId } : {}),
       ...(draftModelOptions ? { draftModelOptions } : {}),
       ...(selectedProjectId ? { selectedProjectId } : {}),
       ...(selectedThreadId ? { selectedThreadId } : {}),
@@ -3193,6 +3196,7 @@ export function App({
     prefsReady,
     paths,
     appSettings,
+    tuiThemeId,
     composerDraftsByThreadId,
     expandedProjectIds,
     selectedProjectId,
@@ -3474,6 +3478,7 @@ export function App({
       : appSettings.theme === "light"
         ? "Light"
         : "Dark";
+  const selectedTuiThemeLabel = TUI_THEME_LABELS[tuiThemeId] ?? TUI_THEME_LABELS.default;
   const selectedThreadEnvLabel =
     appSettings.defaultThreadEnvMode === "worktree" ? "New worktree" : "Local";
   const composerEnvMenuItems: ComposerEnvMenuItem[] = ENV_MODE_OPTIONS.map((option) => ({
@@ -3553,6 +3558,16 @@ export function App({
             setOverlayMenu(null);
           },
         }));
+      case "theme-preset":
+        return TUI_THEME_OPTIONS.map((option) => ({
+          id: option,
+          label: TUI_THEME_LABELS[option],
+          selected: tuiThemeId === option,
+          onSelect: () => {
+            setTuiThemeId(option);
+            setOverlayMenu(null);
+          },
+        }));
       case "timestamp-format":
         return TIMESTAMP_FORMAT_OPTIONS.map((option) => ({
           id: option,
@@ -3602,6 +3617,7 @@ export function App({
     gitTextGenerationModelOptions,
     selectedCustomModelProvider,
     settingsSelectKind,
+    tuiThemeId,
     updateAppSettings,
   ]);
   const sidebarSortItems = useMemo<SidebarSortMenuItem[]>(
@@ -3644,6 +3660,7 @@ export function App({
   );
   const changedSettingLabels = [
     ...(appSettings.theme !== DEFAULT_APP_THEME ? ["Theme"] : []),
+    ...(tuiThemeId !== DEFAULT_TUI_THEME_ID ? ["Theme preset"] : []),
     ...(appSettings.timestampFormat !== DEFAULT_TIMESTAMP_FORMAT ? ["Time format"] : []),
     ...(appSettings.sidebarProjectSortOrder !== DEFAULT_SIDEBAR_PROJECT_SORT_ORDER
       ? ["Project sort"]
@@ -5554,6 +5571,7 @@ export function App({
 
   function restoreDefaultSettings() {
     setAppSettings(DEFAULT_APP_SETTINGS);
+    setTuiThemeId(DEFAULT_TUI_THEME_ID);
     setOpenInstallProviders({ codex: false, claudeAgent: false });
     setSelectedCustomModelProvider("codex");
     setCustomModelInputByProvider({ codex: "", claudeAgent: "" });
@@ -7429,13 +7447,15 @@ export function App({
   const settingsSelectTitle =
     settingsSelectKind === "theme"
       ? "Theme"
-      : settingsSelectKind === "timestamp-format"
-        ? "Time format"
-        : settingsSelectKind === "thread-env"
-          ? "New threads"
-          : settingsSelectKind === "custom-model-provider"
-            ? "Custom model provider"
-            : "Text generation model";
+      : settingsSelectKind === "theme-preset"
+        ? "Theme preset"
+        : settingsSelectKind === "timestamp-format"
+          ? "Time format"
+          : settingsSelectKind === "thread-env"
+            ? "New threads"
+            : settingsSelectKind === "custom-model-provider"
+              ? "Custom model provider"
+              : "Text generation model";
   const settingsSelectPopupWidth = Math.max(
     14,
     settingsSelectItems.reduce(
@@ -7929,7 +7949,11 @@ export function App({
                                     SIDEBAR_THREAD_TITLE_WIDTH,
                                   )}
                                   style={{
-                                    fg: isActive || isSelected ? PALETTE.text : PALETTE.muted,
+                                    fg: isSelected
+                                      ? ACTIVE_TUI_THEME.colors.selectedText
+                                      : isActive
+                                        ? PALETTE.text
+                                        : PALETTE.muted,
                                   }}
                                 />
                               </box>
@@ -7944,7 +7968,11 @@ export function App({
                                 <text
                                   content={formatRelativeTime(thread.updatedAt)}
                                   style={{
-                                    fg: isActive || isSelected ? PALETTE.muted : PALETTE.subtle,
+                                    fg: isSelected
+                                      ? ACTIVE_TUI_THEME.colors.selectedText
+                                      : isActive
+                                        ? PALETTE.muted
+                                        : PALETTE.subtle,
                                     flexShrink: 0,
                                   }}
                                 />
@@ -8176,6 +8204,28 @@ export function App({
                                 overlayMenu === "settings-select" && settingsSelectKind === "theme"
                               }
                               onPress={(event) => openSettingsSelectMenu("theme", event)}
+                            />
+                          }
+                        />
+                        <SettingsRow
+                          title="Theme preset"
+                          description="Default uses the built-in palette. Terminal Match derives colors from your terminal palette."
+                          resetAction={
+                            tuiThemeId !== DEFAULT_TUI_THEME_ID ? (
+                              <SettingResetButton
+                                onPress={() => setTuiThemeId(DEFAULT_TUI_THEME_ID)}
+                              />
+                            ) : null
+                          }
+                          control={
+                            <ToolbarButton
+                              label={`${selectedTuiThemeLabel} ▾`}
+                              surface="inset"
+                              active={
+                                overlayMenu === "settings-select" &&
+                                settingsSelectKind === "theme-preset"
+                              }
+                              onPress={(event) => openSettingsSelectMenu("theme-preset", event)}
                             />
                           }
                         />
@@ -8833,14 +8883,14 @@ export function App({
                                 showLineNumbers
                                 wrapMode="none"
                                 {...(file.filetype ? { filetype: file.filetype } : {})}
-                                addedBg="#173124"
-                                removedBg="#3a1f1f"
-                                addedContentBg="#1d3a2b"
-                                removedContentBg="#442525"
+                                addedBg={ACTIVE_TUI_THEME.diffViewer.addedBg}
+                                removedBg={ACTIVE_TUI_THEME.diffViewer.removedBg}
+                                addedContentBg={ACTIVE_TUI_THEME.diffViewer.addedContentBg}
+                                removedContentBg={ACTIVE_TUI_THEME.diffViewer.removedContentBg}
                                 contextBg={PALETTE.main}
                                 lineNumberBg={PALETTE.surface}
-                                addedSignColor="#4ade80"
-                                removedSignColor="#f87171"
+                                addedSignColor={ACTIVE_TUI_THEME.diffViewer.addedSignColor}
+                                removedSignColor={ACTIVE_TUI_THEME.diffViewer.removedSignColor}
                                 style={{
                                   flexGrow: 1,
                                   minHeight: 8,
@@ -10327,7 +10377,9 @@ export function App({
                 }
                 label={item.label}
                 active={index === sidebarContextMenu.selectedIndex}
-                {...(item.destructive ? { iconColor: "#fda4af" } : {})}
+                {...(item.destructive
+                  ? { iconColor: ACTIVE_TUI_THEME.colors.destructiveIcon }
+                  : {})}
                 onHover={() =>
                   setSidebarContextMenu((current) =>
                     current


### PR DESCRIPTION
What this PR does
- Adds terminal-aware theming to the TUI with a new `Terminal Match` preset.
- Extracts the TUI theme system out of `ui.tsx` and into `theme.ts`, replacing hardcoded colors.
- Applies the resolved theme on startup and keeps it in sync when the terminal reports theme-mode changes.

How it works
- Uses OpenTUI's `renderer.getPalette({ size: 16 })` directly to read the active terminal palette.
- Follows the same core approach OpenCode uses for its `system` theme: derive the UI from the terminal's real background, foreground, and ANSI 0-15 colors rather than from a fixed built-in palette.
- Builds semantic TUI colors from that palette: neutral surfaces are derived from the terminal background, while accents, status colors, and diff colors come from the ANSI palette.
- If OpenTUI cannot provide a usable palette, the TUI falls back to the built-in default preset.

Examples of dark themes:
![Image](https://github.com/user-attachments/assets/4aaff36c-8a2e-4541-ae2d-1e0ed4a74157)

Examples of light themes:
![Image](https://github.com/user-attachments/assets/91bae89f-0168-43a7-8c11-ddf484c6757a)

Where the preset lives:
<img width="1119" height="166" alt="image" src="https://github.com/user-attachments/assets/30304add-16aa-4c86-9421-db695dd5e755" />

Closes #11 