### PR TITLE
Fix missing noopener on external chat markdown links

### DIFF
--- a/apps/web/src/components/ChatMarkdown.test.tsx
+++ b/apps/web/src/components/ChatMarkdown.test.tsx
@@ -1,0 +1,19 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../hooks/useTheme", () => ({
+  useTheme: () => ({ theme: "light", setTheme: vi.fn(), resolvedTheme: "light" as const }),
+}));
+
+import ChatMarkdown from "./ChatMarkdown";
+
+describe("ChatMarkdown", () => {
+  it("adds noopener to external links opened in a new tab", () => {
+    const markup = renderToStaticMarkup(
+      <ChatMarkdown text="[docs](https://example.com/docs)" cwd={undefined} />,
+    );
+
+    expect(markup).toContain('target="_blank"');
+    expect(markup).toContain('rel="noopener noreferrer"');
+  });
+});

--- a/apps/web/src/components/ChatMarkdown.tsx
+++ b/apps/web/src/components/ChatMarkdown.tsx
@@ -243,7 +243,7 @@ function ChatMarkdown({ text, cwd, isStreaming = false }: ChatMarkdownProps) {
       a({ node: _node, href, ...props }) {
         const targetPath = resolveMarkdownFileLinkTarget(href, cwd);
         if (!targetPath) {
-          return <a {...props} href={href} target="_blank" rel="noreferrer" />;
+          return <a {...props} href={href} target="_blank" rel="noopener noreferrer" />;
         }
 
         return (


### PR DESCRIPTION
## Summary
External links rendered by `ChatMarkdown` opened in a new tab with `rel="noreferrer"` but without `noopener`.

This path is used for links that are not resolved to local workspace files, so the web UI was missing the standard hardening that prevents the opened page from getting a handle back to the opener.

## What changed
- add `noopener` alongside `noreferrer` for external markdown links rendered in `ChatMarkdown`
- add a focused regression test that asserts the rendered anchor includes the expected new-tab attributes

## Verification
- `bun x vitest run apps/web/src/components/ChatMarkdown.test.tsx`
- `bun fmt --check`
- `bun lint`
- `bun typecheck`
